### PR TITLE
skip team set when client in spec

### DIFF
--- a/src/game/server/player_ddpp.cpp
+++ b/src/game/server/player_ddpp.cpp
@@ -205,7 +205,7 @@ void CPlayer::DDPPTick()
 	//dragon test chillers level system xp money usw am start :3
 	CheckLevel();
 
-	if(m_ChangeTeamOnFlag || (Server()->Tick() % 600 == 0))
+	if((m_ChangeTeamOnFlag || (Server()->Tick() % 600 == 0)) && m_Team != TEAM_SPECTATORS)
 	{
 		if((((CGameControllerDDRace *)GameServer()->m_pController)->HasFlag(GetCharacter()) == -1) && m_IsDummy && ((g_Config.m_SvShowBotsInScoreboard == 1 && (m_DummyMode >= -6 && m_DummyMode <= -1)) || g_Config.m_SvShowBotsInScoreboard == 0))
 		{

--- a/src/game/server/player_ddpp.cpp
+++ b/src/game/server/player_ddpp.cpp
@@ -205,9 +205,9 @@ void CPlayer::DDPPTick()
 	//dragon test chillers level system xp money usw am start :3
 	CheckLevel();
 
-	if((m_ChangeTeamOnFlag || (Server()->Tick() % 600 == 0)) && m_Team != TEAM_SPECTATORS)
+	if((m_ChangeTeamOnFlag || (Server()->Tick() % 600 == 0)) && m_Team != TEAM_SPECTATORS && m_IsDummy)
 	{
-		if((((CGameControllerDDRace *)GameServer()->m_pController)->HasFlag(GetCharacter()) == -1) && m_IsDummy && ((g_Config.m_SvShowBotsInScoreboard == 1 && (m_DummyMode >= -6 && m_DummyMode <= -1)) || g_Config.m_SvShowBotsInScoreboard == 0))
+		if((((CGameControllerDDRace *)GameServer()->m_pController)->HasFlag(GetCharacter()) == -1) && ((g_Config.m_SvShowBotsInScoreboard == 1 && (m_DummyMode >= -6 && m_DummyMode <= -1)) || g_Config.m_SvShowBotsInScoreboard == 0))
 		{
 			m_Team = TEAM_BLUE;
 		}


### PR DESCRIPTION
Atm when client join spectator after 600 ticks it joins back after team set to 0 (TEAM_RED), not sure that my PR is correct solution, but at least need do check for spectator here

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
