### PR TITLE
reworked weapon drop, fixed crash

### DIFF
--- a/src/game/server/entities/weapon.cpp
+++ b/src/game/server/entities/weapon.cpp
@@ -44,12 +44,17 @@ void CWeapon::Reset()
 	{
 		CPlayer *pOwner = GameServer()->m_apPlayers[m_Owner];
 		if(pOwner)
-			for(unsigned i = 0; i < pOwner->m_vWeaponLimit[m_Type].size(); i++)
-				if(pOwner->m_vWeaponLimit[m_Type][i] == this)
+		{
+			std::vector<CWeapon *> &DroppedWeapons = pOwner->m_aWeaponLimit[m_Type];
+			for(unsigned i = 0; i < DroppedWeapons.size(); i++)
+			{
+				if(DroppedWeapons[i] == this)
 				{
-					pOwner->m_vWeaponLimit[m_Type].erase(pOwner->m_vWeaponLimit[m_Type].begin() + i);
+					DroppedWeapons.erase(DroppedWeapons.begin() + i);
 					break;
 				}
+			}
+		}
 	}
 
 	if(IsCharacterNear() == -1)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1685,6 +1685,8 @@ void CGameContext::OnClientConnected(int ClientID, void *pData)
 	m_apPlayers[ClientID]->SetAfk(Afk);
 	NextUniqueClientID += 1;
 
+	m_ClientLeftServer[ClientID] = false;
+
 #ifdef CONF_DEBUG
 	if(g_Config.m_DbgDummies)
 	{

--- a/src/game/server/player_ddpp.cpp
+++ b/src/game/server/player_ddpp.cpp
@@ -77,7 +77,6 @@ void CPlayer::ResetDDPP()
 		m_IsVanillaDmg = true;
 		m_IsVanillaWeapons = true;
 	}
-	m_vWeaponLimit.resize(5);
 
 	m_MoneyTilesMoney = 0;
 	str_copy(m_aTradeOffer, "", sizeof(m_aTradeOffer));

--- a/src/game/server/player_ddpp.h
+++ b/src/game/server/player_ddpp.h
@@ -237,7 +237,7 @@ public:
 	int m_SpawnGrenadeActive;
 	int m_SpawnRifleActive;
 
-	std::vector<std::vector<CWeapon *>> m_vWeaponLimit;
+	std::vector<CWeapon *> m_aWeaponLimit[NUM_WEAPONS];
 
 	//city stuff
 	//int m_broadcast_animation; //idk if this var will be used. plan: check for a running animation and animate it //try in gamecontext.cpp


### PR DESCRIPTION
due to wrongly removed `m_ClientLeftServer[ClientID] = false;` weapon drop became broken
Step to reproduce crash:
1. 2 players on server, you and dummy (to prevent reload)
2. dummy drop weapon
3. dummy leave server
4. dummy join server
5. dummy press f4 (drop button) 5 times (weapon immediately picked up due to bug)
6. server crashed on trying to reset wrong pointer

while searching for that bug rewrited weapons drop method a bit, so commit it too

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
