### PR TITLE
Fix invalid buffer size passed to str_timestamp_ex

### DIFF
--- a/src/engine/shared/filecollection.cpp
+++ b/src/engine/shared/filecollection.cpp
@@ -35,7 +35,7 @@ void CFileCollection::Init(IStorage *pStorage, const char *pPath, const char *pF
 		else
 		{
 			char aTimestring[TIMESTAMP_LENGTH];
-			str_timestamp_ex(FileEntry.m_Timestamp, aTimestring, sizeof(aBuf), FORMAT_NOSPACE);
+			str_timestamp_ex(FileEntry.m_Timestamp, aTimestring, sizeof(aTimestring), FORMAT_NOSPACE);
 			str_format(aBuf, sizeof(aBuf), "%s/%s_%s%s", m_aPath, m_aFileDesc, aTimestring, m_aFileExt);
 		}
 


### PR DESCRIPTION
Used the correct buffer size (aTimestring) instead of aBuf when calling str_timestamp_ex to avoid overflow and fix compiler warning.

```
/tw/sources/src/engine/shared/filecollection.cpp:37:30: note: at offset 511 into destination object 'aTimestring' of size 20                                                                                                                                       
 => => #    37 |                         char aTimestring[TIMESTAMP_LENGTH];
 ```