### PR TITLE
++ fix implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20

### DIFF
--- a/src/game/server/minigames/one_vs_one_block.cpp
+++ b/src/game/server/minigames/one_vs_one_block.cpp
@@ -189,15 +189,15 @@ void COneVsOneBlock::OnRoundStart(CPlayer *pPlayer1, CPlayer *pPlayer2)
 	{
 		pChr->RequestTeleToTile(TILE_BLOCK_DM_A1, pGameState->m_SpawnCounter++)
 			.DelayInSeconds(3)
-			.OnPreSuccess([=]() {
+			.OnPreSuccess([=, this]() {
 				if(pChr->GetPlayer()->m_pBlockOneVsOneState == pGameState)
 					SavePosition(pChr->GetPlayer());
 			})
-			.OnPostSuccess([=]() {
+			.OnPostSuccess([=, this]() {
 				if(pChr->GetPlayer()->m_pBlockOneVsOneState == pGameState)
 					OnTeleportSuccess(pGameState, pChr->GetPlayer());
 			})
-			.OnFailure([=](const char *pShort, const char *pLong) {
+			.OnFailure([=, this](const char *pShort, const char *pLong) {
 				char aError[512];
 				str_format(aError, sizeof(aError), "[1vs1] game aborted '%s' failed to teleport (%s)", Server()->ClientName(pChr->GetPlayer()->GetCid()), pShort);
 				SendChatTarget(pPlayer1->GetCid(), aError);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

For some reason @ChillerDragon your commit https://github.com/DDNetPP/DDNetPP/commit/09b7d4a28fbfd934b8ec2281edc9805cfc9ed4ed didn't change anything :?

https://github.com/DDNetPP/DDNetPP/actions/runs/16215918878/job/45785208360

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
